### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
 # NetWatch
-NetWatch is a Python module for network traffic analysis. 
+NetWatch is a Python module that provides network traffic analysis capabilities. It can be used to extract information such as user credentials, URLs, or other sensitive data from network traffic. This can be useful for monitoring network activity for security breaches, or for analyzing traffic patterns for optimization purposes.
+
+# Features
+Network traffic analysis: NetWatch can analyze network traffic and extract information such as user credentials, URLs, or other sensitive data.
+Customizable analysis: The user can define their own analysis rules to extract specific information from the network traffic.
+Live packet capture: NetWatch can capture and analyze network traffic in real-time.
+Offline analysis: NetWatch can analyze pre-captured network traffic in pcap or pcapng format.
+
+# Installation
+To install NetWatch, you can use pip:
+```
+pip install netwatch
+```
+
+# Usage
+NetWatch can be used both as a module in your own Python code or as a standalone command-line tool.
+
+# As a module
+Here is an example of how to use NetWatch as a module in your Python code:
+```
+import netwatch
+
+# Create a NetWatch object with default settings
+nw = netwatch.NetWatch()
+
+# Analyze network traffic in real-time
+nw.analyze_live()
+
+# Analyze pre-captured network traffic
+nw.analyze_offline('path/to/captured_traffic.pcap')
+```
+
+# As a command-line tool
+NetWatch can also be used as a command-line tool. Here is an example of how to use it to capture and analyze network traffic in real-time:
+```
+netwatch live
+```
+And here is an example of how to use it to analyze pre-captured network traffic:
+
+```
+netwatch offline path/to/captured_traffic.pcap
+```
+
+# Customization
+NetWatch can be customized to extract specific information from network traffic. This can be done by defining your own analysis rules. Analysis rules are defined using regular expressions and can be added to NetWatch using the `add_rule()` method.
+
+Here is an example of how to define an analysis rule to extract email addresses from network traffic:
+```
+import netwatch
+
+nw = netwatch.NetWatch()
+
+email_regex = r'[\w\.-]+@[\w\.-]+'
+
+nw.add_rule('Email addresses', email_regex)
+```
+
+# Contributions
+Contributions are welcome! If you have an idea for a new feature, feel free to open an issue or submit a pull request.
+
+# License
+NetWatch is released under the MIT License. See LICENSE for more information.
+
+# Acknowledgements
+NetWatch was inspired by the following projects:
+
+- Scapy: https://scapy.net/
+- Wireshark: https://www.wireshark.org/
+
+# Contact
+If you have any questions or comments about NetWatch, feel free to contact us at juniordeveloper@gmail.com.
+


### PR DESCRIPTION
# NetWatch
NetWatch is a Python module that provides network traffic analysis capabilities. It can be used to extract information such as user credentials, URLs, or other sensitive data from network traffic. This can be useful for monitoring network activity for security breaches, or for analyzing traffic patterns for optimization purposes.

# Features
Network traffic analysis: NetWatch can analyze network traffic and extract information such as user credentials, URLs, or other sensitive data.
Customizable analysis: The user can define their own analysis rules to extract specific information from the network traffic.
Live packet capture: NetWatch can capture and analyze network traffic in real-time.
Offline analysis: NetWatch can analyze pre-captured network traffic in pcap or pcapng format.

# Installation
To install NetWatch, you can use pip:
```
pip install netwatch
```

# Usage
NetWatch can be used both as a module in your own Python code or as a standalone command-line tool.

# As a module
Here is an example of how to use NetWatch as a module in your Python code:
```
import netwatch

# Create a NetWatch object with default settings
nw = netwatch.NetWatch()

# Analyze network traffic in real-time
nw.analyze_live()

# Analyze pre-captured network traffic
nw.analyze_offline('path/to/captured_traffic.pcap')
```

# As a command-line tool
NetWatch can also be used as a command-line tool. Here is an example of how to use it to capture and analyze network traffic in real-time:
```
netwatch live
```
And here is an example of how to use it to analyze pre-captured network traffic:

```
netwatch offline path/to/captured_traffic.pcap
```

# Customization
NetWatch can be customized to extract specific information from network traffic. This can be done by defining your own analysis rules. Analysis rules are defined using regular expressions and can be added to NetWatch using the `add_rule()` method.

Here is an example of how to define an analysis rule to extract email addresses from network traffic:
```
import netwatch

nw = netwatch.NetWatch()

email_regex = r'[\w\.-]+@[\w\.-]+'

nw.add_rule('Email addresses', email_regex)
```

# Contributions
Contributions are welcome! If you have an idea for a new feature, feel free to open an issue or submit a pull request.

# License
NetWatch is released under the MIT License. See LICENSE for more information.

# Acknowledgements
NetWatch was inspired by the following projects:

- Scapy: https://scapy.net/
- Wireshark: https://www.wireshark.org/

# Contact
If you have any questions or comments about NetWatch, feel free to contact us at juniordeveloper@gmail.com.

